### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IamJayPrakash/subnexa/security/code-scanning/2](https://github.com/IamJayPrakash/subnexa/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out the repository and running Node.js commands), the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` used by the workflow has only the necessary permissions to access the repository contents, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `permissions` with `contents: read` to the GitHub Actions workflow configuration file `.github/workflows/ci.yml`.

### Why are these changes being made?

This change addresses a code scanning alert indicating that the workflow doesn't specify permissions. Specifying `contents: read` ensures minimal permissions required for the action, enhancing security by adhering to the principle of least privilege.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->