### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IamJayPrakash/subnexa/security/code-scanning/1](https://github.com/IamJayPrakash/subnexa/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since this is a linting workflow, it only needs read access to the repository contents. We will set `contents: read` as the permission, which is the minimal privilege required for this workflow to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made? 

Add read-only permissions to the `.github/workflows/lint.yml` file for contents access.

### Why are these changes being made?

This change addresses a code scanning alert that identified the workflow lacked specified permissions, potentially enhancing security by explicitly setting read-only permissions for the contents to mitigate unintended access. This approach aligns with best practices for security management in GitHub workflows.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->